### PR TITLE
Improve bookmark page performance and fix some errors

### DIFF
--- a/src/components/Card/DetailCard.js
+++ b/src/components/Card/DetailCard.js
@@ -72,6 +72,9 @@ const DetailCard = props => {
         };
 
         if (!bookmarked) {
+            setBookmarked(true);
+            setChipText(ADDED_TO_BOOKMARK_TEXT);
+            setIsChipVisible(true);
             axios
                 .post(
                     ServerConfig.api.ip + bookmarkApi,
@@ -80,12 +83,12 @@ const DetailCard = props => {
                     },
                     { headers: headers }
                 )
-                .then(() => {
-                    setBookmarked(true);
-                    setChipText(ADDED_TO_BOOKMARK_TEXT);
-                    setIsChipVisible(true);
-                });
+                .then(() => {})
+                .catch(() => {});
         } else {
+            setBookmarked(false);
+            setChipText(REMOVED_TO_BOOKMARK_TEXT);
+            setIsChipVisible(true);
             axios
                 .delete(ServerConfig.api.ip + bookmarkApi, {
                     headers: headers,
@@ -93,11 +96,8 @@ const DetailCard = props => {
                         concept_card_id: props.id
                     }
                 })
-                .then(() => {
-                    setBookmarked(false);
-                    setChipText(REMOVED_TO_BOOKMARK_TEXT);
-                    setIsChipVisible(true);
-                });
+                .then(() => {})
+                .catch(() => {});
         }
     };
 

--- a/src/components/commons/DetailPage.js
+++ b/src/components/commons/DetailPage.js
@@ -8,6 +8,7 @@ import DetailCard from "../Card/DetailCard";
 import qs from "query-string";
 import axios from "axios";
 import ServerConfig from "../../configs/ServerConfig";
+import { isAuthenticated } from "../../utils/auth";
 
 const sStudyCardApi = "/api/v1/card/studycard";
 const bookmarkApi = "/api/v1/bookmark";
@@ -69,7 +70,9 @@ const DetailPage = props => {
 
     useEffect(() => {
         getStudyCardById(studyCardId);
-        getBookmarks();
+        if (isAuthenticated()) {
+            getBookmarks();
+        }
     }, [studyCardId]);
 
     const backArrowOnClickHandler = () => {

--- a/src/components/commons/ProfilePage.js
+++ b/src/components/commons/ProfilePage.js
@@ -42,12 +42,17 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const ProfilePage = props => {
-    doAuthentication(props.history);
+    const [isLogout, setIsLogout] = useState(false);
+    useEffect(() => {
+        doAuthentication(props.history);
+    }, [isLogout, props.history]);
+
     const classes = useStyles();
     const [userProfile, setUserProfile] = useState({
         username: "",
         email: ""
     });
+
     useEffect(() => {
         const getRequestHeader = {
             token: window.localStorage.getItem("token")
@@ -70,11 +75,10 @@ const ProfilePage = props => {
                 });
             });
     }, []);
-    const [isLogingOut, setIsLogingOut] = useState(false);
+
     const onLogoutHandler = () => {
-        setIsLogingOut(true);
         window.localStorage.removeItem("token");
-        setIsLogingOut(false);
+        setIsLogout(true);
     };
     return (
         <div className="ProfilePage">
@@ -121,7 +125,6 @@ const ProfilePage = props => {
                     aria-label="logout"
                     className={classes.logout}
                     onClick={onLogoutHandler}
-                    disabled={isLogingOut ? true : false}
                 >
                     Logout
                 </Fab>


### PR DESCRIPTION
+ If we wait for request response before we set state for bookmark, it will be laggy.
   Therefore, we set state for bookmark immediately to improve user experience.
+ Fix error when no login users enter DetailPage, we do not want to send request
   to check bookmarks.
+ Fix error when react-router is setting state during re-render phase. We need to
   push new location to history using side effect so that we can avoid error about
   setting state during render phase.
   Setting state during render phase could cause infinite loop.