### PR TITLE
Fix an issue where the width of  flashcard definition side shrinks

### DIFF
--- a/src/components/Card/Flashcard.js
+++ b/src/components/Card/Flashcard.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles(theme => ({
     },
     cardFront: {
         position: "absolute",
+        width: "100%",
         top: 0,
         left: 0,
         display: "flex",


### PR DESCRIPTION
- We need to explicitly set the width of card front to 100% so that the width
  of definition side does not shrink if content width is small because cardfront
  is displayed as flex